### PR TITLE
Update HASHSERVER and poky to a more recent version

### DIFF
--- a/build_firmware.sh
+++ b/build_firmware.sh
@@ -2,7 +2,7 @@ git clone git://git.yoctoproject.org/poky -b kirkstone
 cd poky; 
 
 #checkout the tested version of the layer Poky
-git checkout 72ddfbc89aa94c2a4adfe2b8545c52fc2a0065ab
+git checkout 959405cc371df8d51bbd41e7ee970a943c738297
 
 ln -s ../meta-jsdelivr/ meta-jsdelivr
 

--- a/meta-jsdelivr/build_conf/local.conf
+++ b/meta-jsdelivr/build_conf/local.conf
@@ -80,7 +80,10 @@ BUILD_REPRODUCIBLE_BINARIES_pn-linux-mainline="0"
 
 BB_SIGNATURE_HANDLER = "OEEquivHash"
 BB_HASHSERVE = "auto"
-BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
+BB_HASHSERVE_UPSTREAM = "hashserv.yoctoproject.org:8686"
 SSTATE_MIRRORS ?= "file://.* http://cdn.jsdelivr.net/yocto/sstate/all/PATH;downloadfilename=PATH"
+
+
+INHERIT += "rm_work"
 
 


### PR DESCRIPTION
This fixes issues with the access of the old Hashserver, I also added rm_work to the configuration to reduce used space